### PR TITLE
fix: RT calculation not correct under certain circumstances

### DIFF
--- a/src/process-packet.c
+++ b/src/process-packet.c
@@ -137,14 +137,20 @@ process_ip(pcap_t *dev, const struct ip *ip, struct timeval tv) {
             lport = dport;
             rport = sport;
             
-            inbound(tv, ip->ip_dst, ip->ip_src, lport, rport);
+            if (lport == port)
+                inbound(tv, ip->ip_dst, ip->ip_src, lport, rport);
+            else
+                return 1;
             
         }
         else {
             lport = sport;
             rport = dport;
-            
-            outbound(tv, ip->ip_src, ip->ip_dst, lport, rport);
+
+            if (lport == port)
+                outbound(tv, ip->ip_src, ip->ip_dst, lport, rport);
+            else
+                return 1;
             
         }
 


### PR DESCRIPTION
As we can see, it will capture all the packets match with 'port' as bellow,
    if (port)
        sprintf(filter, "tcp port %d", port);
     pcap_compile(pcap, &bpf, filter, 1, 0)

but it doesn't distinguish the src port and dst port.
If this 'server' works as 'client' and connect other server with this port,
it will generate wrong RT value.

This patch is to fix this circumstance.